### PR TITLE
Update code to work on latest D runtime

### DIFF
--- a/source/fast/buffer.d
+++ b/source/fast/buffer.d
@@ -167,7 +167,7 @@ struct TempBuffer(T)
 	@property size_t size() @safe pure nothrow { return T.sizeof * this.slice.length; }
 	@property size_t length() @safe pure nothrow { return this.slice.length; }
 	alias opDollar = length;
-	@property T* ptr() @safe pure nothrow { return this.slice.ptr; }
+	@property T* ptr() @safe pure nothrow { return &this.slice[0]; }
 	alias ptr this;
 
 	auto makeOutputRange()

--- a/source/fast/json.d
+++ b/source/fast/json.d
@@ -35,7 +35,7 @@ import std.exception;
 import std.file;
 import std.json;
 import std.range;
-import std.string;
+import std.string : representation, format;
 import std.traits;
 import std.typecons;
 import std.uni;


### PR DESCRIPTION
- Be explicit about imports for std.string which introduced its own version of isNumeric, conflicting with traits (the one we use)
- Fix deprecation warning about `.ptr` in @safe code

All tests pass on DMD v2.074.1 (not v2.074.0 due to a regression in isNumeric [Bugzilla 17340](https://issues.dlang.org/show_bug.cgi?id=17340)).

On another note, it would be great if you could cut a release if you merge this, the latest version available on dub doesn't include the [PIC fix](https://github.com/mleise/fast/issues/12) so I've ended up having to source from `~master` instead of pinning a version.